### PR TITLE
Allow specifying a replacer for JSON.stringify in options

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function stringify(obj, options) {
       obj = obj.toJSON()
     }
 
-    var string = JSON.stringify(obj)
+    var string = JSON.stringify(obj, options.replacer || null)
 
     if (string === undefined) {
       return string


### PR DESCRIPTION
This PR allows defining an optional replacer function for the options object, that will be executed for the first stringify step.

This allows cleaning up input upon serialization to remove for instance empty or null values.
Example:

``` 
         stringify(myData, { replacer: function(key,value) {
            if (null == value || value == "" || (typeof value == "object" && value.join && value.join('') == '')) {
                return undefined;
            }
            if (value === false) return 0;
            if (value === true) return 1;
            return value;
        }});
```