### PR TITLE
Allow margins inside delimiters

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 function stringify (obj, options) {
   options = options || {}
   var indent = JSON.stringify([1], null, get(options, 'indent', 2)).slice(2, -3)
+  var addMargin = get(options, 'margins', false)
   var maxLength = (indent === '' ? Infinity : get(options, 'maxLength', 80))
 
   return (function _stringify (obj, currentIndent, reserved) {
@@ -20,7 +21,7 @@ function stringify (obj, options) {
     var length = maxLength - currentIndent.length - reserved
 
     if (string.length <= length) {
-      var prettified = prettify(string)
+      var prettified = prettify(string, addMargin)
       if (prettified.length <= length) {
         return prettified
       }
@@ -70,11 +71,21 @@ function stringify (obj, options) {
 // working on the output of `JSON.stringify` we know that only valid strings
 // are present (unless the user supplied a weird `options.indent` but in
 // that case we don’t care since the output would be invalid anyway).
-var stringOrChar = /("(?:[^\\"]|\\.)*")|[:,]/g
+var stringOrChar = /("(?:[^\\"]|\\.)*")|[:,\][}{]/g
 
-function prettify (string) {
+function prettify (string, addMargin) {
+  var m = addMargin ? ' ' : ''
+  var tokens = {
+    '{': '{' + m,
+    '[': '[' + m,
+    '}': m + '}',
+    ']': m + ']',
+    ',': ', ',
+    ':': ': '
+  }
   return string.replace(stringOrChar, function (match, string) {
-    return string ? match : match + ' '
+    if (string) return match
+    return tokens[match]
   })
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -404,4 +404,22 @@ suite('stringify', function () {
       testMaxLength(NaN)
     })
   })
+
+  suite('options.margins', function () {
+    var obj = {a: [1]}
+    test('if missing, defaults to false', function () {
+      expect(stringify(obj))
+        .to.equal('{"a": [1]}')
+    })
+
+    test('if false, does not add spaces inside delimiters', function () {
+      expect(stringify(obj, { margins: false }))
+        .to.equal('{"a": [1]}')
+    })
+
+    test('if true, adds one space inside delimiters', function () {
+      expect(stringify(obj, { margins: true }))
+        .to.equal('{ "a": [ 1 ] }')
+    })
+  })
 })


### PR DESCRIPTION
Some JSON or JS prettifiers (at least, whatever the default is in VS Code...) put a space just inside brackets, which I find improves the readability of the result considerably.  This PR adds that capability to jspc, under an options key called `margins`.  It could reasonably be a number, like `indent`, but I didn't need that and I'm not sure if anyone would, so I left it as a boolean, instead.