### PR TITLE
Support custom stringify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,34 @@
-### Version 1.1.0 (2018-01-12) ###
+### Version 1.2.0 (2018-04-22)
+
+- Added support for custom `JSON.stringify`. Thanks to @domoritz!
+
+### Version 1.1.0 (2018-01-12)
 
 - Added: The `margins` option. Thanks to @randallsquared!
 
 
-### Version 1.0.4 (2017-04-29) ###
+### Version 1.0.4 (2017-04-29)
 
 - Fixed: String contents are no longer accidentally modified in some cases.
   Thanks to @powellquiring!
 
 
-### Version 1.0.3 (2017-03-30) ###
+### Version 1.0.3 (2017-03-30)
 
 - No code changes. Just trying to get the readme to show on npmjs.com.
 
 
-### Version 1.0.2 (2016-09-08) ###
+### Version 1.0.2 (2016-09-08)
 
 - Improved: Limited npm package contents for a smaller download.
 
 
-### Version 1.0.1 (2014-11-03) ###
+### Version 1.0.1 (2014-11-03)
 
 - Fixed: Commas are now accounted for when calculating the available length of a
   line, so that they do not appear outside `options.maxLength`.
 
 
-### Version 1.0.0 (2014-11-01) ###
+### Version 1.0.0 (2014-11-01)
 
 - Initial release.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ arrays are on one line if they fit (according to `options.maxLength`).
   and braces:
   - `false`: `{"a": [1]}`
   - `true`: `{ "a": [ 1 ] }`
+- stringify: Defaults to `JSON.stringify`. Use this to customize the JSON
+  stringify implementation.
 
 `stringify(obj, {maxLength: 0, indent: indent})` gives the exact same result as
 `JSON.stringify(obj, null, indent)`.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 function stringify (obj, options) {
   options = options || {}
-  var indent = JSON.stringify([1], null, get(options, 'indent', 2)).slice(2, -3)
+  var JSONstringify = get(options, 'stringify', JSON.stringify)
+  var indent = JSONstringify([1], null, get(options, 'indent', 2)).slice(2, -3)
   var addMargin = get(options, 'margins', false)
   var maxLength = (indent === '' ? Infinity : get(options, 'maxLength', 80))
 
@@ -9,7 +10,7 @@ function stringify (obj, options) {
       obj = obj.toJSON()
     }
 
-    var string = JSON.stringify(obj)
+    var string = JSONstringify(obj)
 
     if (string === undefined) {
       return string
@@ -41,7 +42,7 @@ function stringify (obj, options) {
         delimiters = '[]'
       } else {
         Object.keys(obj).forEach(function (key, index, array) {
-          var keyPart = JSON.stringify(key) + ': '
+          var keyPart = JSONstringify(key) + ': '
           var value = _stringify(obj[key], nextIndent,
                                  keyPart.length + comma(array, index))
           if (value !== undefined) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 function stringify (obj, options) {
   options = options || {}
   var JSONstringify = get(options, 'stringify', JSON.stringify)
-  var indent = JSONstringify([1], null, get(options, 'indent', 2)).slice(2, -3)
+  var indent = JSON.stringify([1], null, get(options, 'indent', 2)).slice(2, -3)
   var addMargin = get(options, 'margins', false)
   var maxLength = (indent === '' ? Infinity : get(options, 'maxLength', 80))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-stringify-pretty-compact",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "Simon Lydell",
   "license": "MIT",
   "description": "The best of both `JSON.stringify(obj)` and `JSON.stringify(obj, null, indent)`.",


### PR DESCRIPTION
In particular, I would like to use https://github.com/moll/json-stringify-safe to support circular JSON. 