### PR TITLE
Implement maxNesting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,32 @@ arrays are on one line if they fit (according to `options.maxLength`).
   `JSON.stringify`.
 - maxLength: Defaults to 80. Lines will be tried to be kept at maximum this many
   characters long.
+- maxNesting: Defaults to `Infinity`. The maximum amount of allowed inline nesting for objects or arrays
+
+    By default, the output can contain arbitrary amount of nested structures (as long as
+    the maxLength is not exceeded), like below:
+
+    ```json
+    {"a": [{"b": ["test1", "test2"]}, {"c": true}]}}
+    ```
+
+    When maxNesting is set to `0`, the output doesn't allow any nesting:
+    ```json
+    {
+      "a": [
+        {
+          "b": [
+            "test1",
+            "test2"
+          ]
+        },
+        {
+          "c": true
+        }
+      ]
+    }
+    ```
+
 - margins: Defaults to `false`. Whether or not to add “margins” around brackets
   and braces:
   - `false`: `{"a": [1]}`

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,8 @@ declare module 'json-stringify-pretty-compact' {
   const stringify: (object: any, options?: {
       indent?: number | string,
       maxLength?: number,
-      margins?: boolean
+      margins?: boolean,
+      maxNesting?: number
   }) => string;
   export = stringify;
 }


### PR DESCRIPTION
This PR implements `options.maxNesting`option. It's an additional way to control how arrays and objects are allowed to be inlined. By default, the output can contain arbitrary amount of nested structures (as long as the maxLength is not exceeded), like below:

```json
{"a": [{"b": ["test1", "test2"]}, {"c": true}]}}
```

With maxNesting set to `0`, the output doesn't allow any nesting:
```json
{
  "a": [
    {
      "b": [
        "test1",
        "test2"
      ]
    },
    {
      "c": true
    }
  ]
}
```

I personally prefer having maxNesting as `1`, which looks like this:

```json
{
  "a": [
    {
      "b": ["test1", "test2"]
    },
    {"c": true}
  ]
}
```

Tests and documentation included, should follow existing coding conventions. What do you think? I just directly implemented this feature as it's something we need internally, if you feel like it's too much to merge here, we'll keep using our own fork of this lib internally.

