### PR TITLE
Implement options.arrayMargins and options.objectMargins

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ arrays are on one line if they fit (according to `options.maxLength`).
   and braces:
   - `false`: `{"a": [1]}`
   - `true`: `{ "a": [ 1 ] }`
+- arrayMargins: Defaults to `false`. Whether or not to add “margins” around brackets:
+  - `false`: `{"a": [1]}`
+  - `true`: `{"a": [ 1 ]}`
+- arrayMargins: Defaults to `true`. Whether or not to add “margins” around braces:
+  - `false`: `{"a": [1]}`
+  - `true`: `{ "a": [1] }`
 
 `stringify(obj, {maxLength: 0, indent: indent})` gives the exact same result as
 `JSON.stringify(obj, null, indent)`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,9 @@ declare module 'json-stringify-pretty-compact' {
   const stringify: (object: any, options?: {
       indent?: number | string,
       maxLength?: number,
-      margins?: boolean
+      margins?: boolean,
+      arrayMargins?: boolean,
+      objectMargins?: boolean
   }) => string;
   export = stringify;
 }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ function stringify (obj, options) {
   options = options || {}
   var indent = JSON.stringify([1], null, get(options, 'indent', 2)).slice(2, -3)
   var addMargin = get(options, 'margins', false)
+  var addArrayMargin = get(options, 'arrayMargins', false)
+  var addObjectMargin = get(options, 'objectMargins', false)
   var maxLength = (indent === '' ? Infinity : get(options, 'maxLength', 80))
 
   return (function _stringify (obj, currentIndent, reserved) {
@@ -16,9 +18,12 @@ function stringify (obj, options) {
     }
 
     var length = maxLength - currentIndent.length - reserved
-
     if (string.length <= length) {
-      var prettified = prettify(string, addMargin)
+      var prettified = prettify(string, {
+        addMargin: addMargin,
+        addArrayMargin: addArrayMargin,
+        addObjectMargin: addObjectMargin
+      })
       if (prettified.length <= length) {
         return prettified
       }
@@ -70,16 +75,28 @@ function stringify (obj, options) {
 // that case we don’t care since the output would be invalid anyway).
 var stringOrChar = /("(?:[^\\"]|\\.)*")|[:,\][}{]/g
 
-function prettify (string, addMargin) {
-  var m = addMargin ? ' ' : ''
+function prettify (string, options) {
+  options = options || {}
+
   var tokens = {
-    '{': '{' + m,
-    '[': '[' + m,
-    '}': m + '}',
-    ']': m + ']',
+    '{': '{',
+    '}': '}',
+    '[': '[',
+    ']': ']',
     ',': ', ',
     ':': ': '
   }
+
+  if (options.addMargin || options.addObjectMargin) {
+    tokens['{'] = '{ '
+    tokens['}'] = ' }'
+  }
+
+  if (options.addMargin || options.addArrayMargin) {
+    tokens['['] = '[ '
+    tokens[']'] = ' ]'
+  }
+
   return string.replace(stringOrChar, function (match, string) {
     return string ? match : tokens[match]
   })

--- a/test/index.js
+++ b/test/index.js
@@ -420,5 +420,38 @@ suite('stringify', function () {
       expect(stringify(obj, { margins: true }))
         .to.equal('{ "a": [ 1 ] }')
     })
+
+    test('adds margins even though arrayMargins and objectMargins are set to false', function () {
+      expect(stringify(obj, { margins: true, arrayMargins: false, objectMargins: false }))
+        .to.equal('{ "a": [ 1 ] }')
+    })
+  })
+
+  suite('options.arrayMargins', function () {
+    var obj = {a: [1]}
+
+    test('if missing, defaults to false', function () {
+      expect(stringify(obj))
+        .to.equal('{"a": [1]}')
+    })
+
+    test('if true, adds margins only on arrays', function () {
+      expect(stringify(obj, { arrayMargins: true }))
+        .to.equal('{"a": [ 1 ]}')
+    })
+  })
+
+  suite('options.objectMargins', function () {
+    var obj = {a: [1]}
+
+    test('if missing, defaults to false', function () {
+      expect(stringify(obj))
+        .to.equal('{"a": [1]}')
+    })
+
+    test('if true, adds margins only on objects', function () {
+      expect(stringify(obj, { objectMargins: true }))
+        .to.equal('{ "a": [1] }')
+    })
   })
 })


### PR DESCRIPTION
Allows users to control if they only want margins around brackets (arrays) or braces (objects). Includes tests, documentation and should align with existing coding conventions. 

I'm not sure if they API is the best, but it's explicit and simple now. Other option I considered was:

`{ margins: true }` or `{ margins: { objects: true, arrays: false }`