### PR TITLE
Add `types` property to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "description": "The best of both `JSON.stringify(obj)` and `JSON.stringify(obj, null, indent)`.",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": "lydell/json-stringify-pretty-compact",
   "files": [
     "index.js",


### PR DESCRIPTION
This helps tooling find the types for the package - [its not required if your main declaration file is named index.d.ts and lives at the root of the package (next to index.js), but it is advisable to do so.](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package)