### PR TITLE
Support for use in browser via <script> tag and global `stringify`

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
 // that case we don’t care since the output would be invalid anyway).
 var stringOrChar = /("(?:[^\\"]|\\.)*")|[:,]/g;
 
-module.exports = function stringify(passedObj, options) {
+function stringify(passedObj, options) {
   var indent, maxLength, replacer;
 
   options = options || {};
@@ -100,3 +100,7 @@ module.exports = function stringify(passedObj, options) {
     return string;
   })(passedObj, "", 0);
 };
+
+if (typeof module !== 'undefined') {
+  module.exports = stringify;
+}


### PR DESCRIPTION
I use your `json-stringify-pretty-compact` in a bunch of Node scripts I've written.  Recently, I wanted to use it in a browser app for interactively preparing JSON, and then downloading the file, so I wanted to use `json-stringify-pretty-compact` in a browser context. I found myself doing the following workaround:
```html
<script type="text/javascript">
      module = {};
<script>
<script type="text/javascript" src="node_modules/json-stringify-pretty-compact/index.js"></script>
<script type="text/javascript">
    stringify = module.exports;
</script>
```

This PR makes a tiny change that enables `json-stringify-pretty-compact` in both Node and browser environments, by exposing `stringify` to the global (`window`) scope in a browser environment.  The above code becomes:

```html
<script type="text/javascript" src="node_modules/json-stringify-pretty-compact/index.js"></script>
```

Questions:
* Should the global be `stringify` or something else like `jsonStringifyPrettyCompact`? Up to you.
* `stringOrChar` also gets exposed to the global (`window`) scope.  If this is important, we can wrap everything in a closure to avoid it, but I'm not sure it's that important.  This is mainly for quick hacks (no bundler) anyway.