### PR TITLE
Add CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 node_modules
+
+# jetbrains products
+.idea/
+

--- a/bin/json-stringify-pretty-compact.js
+++ b/bin/json-stringify-pretty-compact.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import stringify from "json-stringify-pretty-compact";
+
+// Display help
+if(process.argv.length < 3 || process.argv[2] === `help` || process.argv[2] === `--help`) {
+    console.log(`Format a file with https://github.com/lydell/json-stringify-pretty-compact
+
+Usage:
+
+json-spc [--indent=<spaces>] [--max-length=<characters>] <file.json> [> newfile.json]
+
+
+Options:
+
+--indent: Defaults to 2. Works exactly like the third parameter of JSON.stringify.
+--max-length: Defaults to 80. Lines will be tried to be kept at maximum this many characters long.
+    `);
+    process.exit(0);
+}
+
+// Parse command line options
+const opts = {}
+if(process.argv.length > 3) {
+    const optMap = {
+        "--indent": `indent`,
+        "--max-length": `maxLength`,
+    }
+    try {
+        const args = process.argv.slice(2, process.argv.length - 1);
+        for(const arg of args) {
+            const parts = arg.split(`=`);
+            if(parts.length !== 2) {
+                throw new Error(`Invalid argument format: ${arg}`);
+            }
+            const key = parts[0];
+            const opt = optMap[key];
+            if(opt === undefined) {
+                throw new Error(`Unknown argument: ${key}`);
+            }
+            const val = parseInt(parts[1]);
+            opts[opt] = val;
+        }
+    } catch (e) {
+        console.error(`Error parsing arguments!`, e);
+        process.exit(3);
+    }
+}
+
+// Read file
+const path = process.argv[process.argv.length - 1];
+if(!fs.existsSync(path)) {
+    console.error(`File not found: ${path}`);
+    process.exit(1);
+}
+
+// Read file
+const text = fs.readFileSync(path, 'utf-8');
+let json;
+try {
+    json = JSON.parse(text);
+} catch (e) {
+    console.error(`Error parsing JSON!`, e);
+    process.exit(2);
+}
+
+// Format
+const output = stringify(json, opts);
+
+// Write output
+console.log(output);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "json-stringify-pretty-compact",
       "version": "3.0.0",
       "license": "MIT",
+      "bin": {
+        "json-spc": "bin/json-stringify-pretty-compact.js",
+        "json-stringify-pretty-compact": "bin/json-stringify-pretty-compact.js"
+      },
       "devDependencies": {
         "eslint": "8.15.0",
         "prettier": "2.6.2"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
   "exports": "./index.js",
   "types": "index.d.ts",
   "repository": "lydell/json-stringify-pretty-compact",
+  "bin": {
+    "json-stringify-pretty-compact": "bin/json-stringify-pretty-compact.js",
+    "json-spc": "bin/json-stringify-pretty-compact.js"
+  },
   "files": [
     "index.js",
     "index.d.ts"


### PR DESCRIPTION
I've only recently discovered `json-stringify-pretty-compact`, but had I known about it sooner it would have saved me hundreds of hours of manually reformatting JSON for various tasks.

Given it's tremendous utility, it would be extremely nice to be able to install it on one's terminal.

This PR adds a `bin/` script that can be `npm link`ed to format JSON files from the terminal.